### PR TITLE
Fixed broken link to auto-ml-remote-amlcompute

### DIFF
--- a/how-to-use-azureml/automated-machine-learning/README.md
+++ b/how-to-use-azureml/automated-machine-learning/README.md
@@ -119,7 +119,7 @@ bash automl_setup_linux.sh
     - Retrieving models for any iteration or logged metric
     - Specify automl settings as kwargs
 
-- [auto-ml-remote-amlcompute.ipynb](remote-batchai/auto-ml-remote-amlcompute.ipynb)
+- [auto-ml-remote-amlcompute.ipynb](remote-amlcompute/auto-ml-remote-amlcompute.ipynb)
     - Dataset: scikit learn's [digit dataset](http://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_digits.html#sklearn.datasets.load_digits)
     - Example of using automated ML for classification using remote AmlCompute for training
     - Parallel execution of iterations


### PR DESCRIPTION
Within MachineLearningNotebooks/how-to-use-azureml/automated-machine-learning/README.md for auto-ml-remote-amlcompute.ipynb